### PR TITLE
Improvement record setting ui/ux and fix some bug

### DIFF
--- a/Packages/io.github.ruccho.ffmpegrecorder/Editor/Scripts/FFmpegPreset.cs
+++ b/Packages/io.github.ruccho.ffmpegrecorder/Editor/Scripts/FFmpegPreset.cs
@@ -1,0 +1,136 @@
+
+namespace Ruccho.FFmpegRecorder
+{
+    public enum FFmpegPreset
+    {
+        H264Default,
+        H264Nvidia,
+        H264Lossless420,
+        H264Lossless444,
+        HevcDefault,
+        HevcNvidia,
+        ProRes422,
+        ProRes4444,
+        VP8Default,
+        VP9Default,
+        Hap,
+        HapAlpha,
+        HapQ
+    }
+
+    public static class FFmpegPresetExtensions
+    {
+        public static string GetDisplayName(this FFmpegPreset preset)
+        {
+            switch (preset)
+            {
+                case FFmpegPreset.H264Default: return "H.264 Default (MP4)";
+                case FFmpegPreset.H264Nvidia: return "H.264 NVIDIA (MP4)";
+                case FFmpegPreset.H264Lossless420: return "H.264 Lossless 420 (MP4)";
+                case FFmpegPreset.H264Lossless444: return "H.264 Lossless 444 (MP4)";
+                case FFmpegPreset.HevcDefault: return "HEVC Default (MP4)";
+                case FFmpegPreset.HevcNvidia: return "HEVC NVIDIA (MP4)";
+                case FFmpegPreset.ProRes422: return "ProRes 422 (QuickTime)";
+                case FFmpegPreset.ProRes4444: return "ProRes 4444 (QuickTime)";
+                case FFmpegPreset.VP8Default: return "VP8 (WebM)";
+                case FFmpegPreset.VP9Default: return "VP9 (WebM)";
+                case FFmpegPreset.Hap: return "HAP (QuickTime)";
+                case FFmpegPreset.HapAlpha: return "HAP Alpha (QuickTime)";
+                case FFmpegPreset.HapQ: return "HAP Q (QuickTime)";
+            }
+
+            return null;
+        }
+
+        public static string GetSuffix(this FFmpegPreset preset)
+        {
+            switch (preset)
+            {
+                case FFmpegPreset.H264Default:
+                case FFmpegPreset.H264Nvidia:
+                case FFmpegPreset.H264Lossless420:
+                case FFmpegPreset.H264Lossless444:
+                case FFmpegPreset.HevcDefault:
+                case FFmpegPreset.HevcNvidia: return "mp4";
+                case FFmpegPreset.ProRes422:
+                case FFmpegPreset.ProRes4444: return "mov";
+                case FFmpegPreset.VP9Default:
+                case FFmpegPreset.VP8Default: return "webm";
+                case FFmpegPreset.Hap:
+                case FFmpegPreset.HapQ:
+                case FFmpegPreset.HapAlpha: return "mov";
+            }
+
+            return null;
+        }
+
+        public static string GetVideoCodec(this FFmpegPreset preset)
+        {
+            //If no choice -c:v(videocodec) it will use default codec(libx264)
+            //Hevc is mean h265(libx265)
+            switch (preset)
+            {
+                case FFmpegPreset.H264Default: 
+                case FFmpegPreset.H264Nvidia: 
+                case FFmpegPreset.H264Lossless420: 
+                case FFmpegPreset.H264Lossless444: return "libx264";
+                case FFmpegPreset.HevcDefault: return "libx265";
+                case FFmpegPreset.HevcNvidia: return "hevc_nvenc";
+                case FFmpegPreset.ProRes422:
+                case FFmpegPreset.ProRes4444: return "prores_ks";
+                case FFmpegPreset.VP8Default: return "libvpx";
+                case FFmpegPreset.VP9Default: return "libvpx-vp9";
+                case FFmpegPreset.Hap: 
+                case FFmpegPreset.HapAlpha: 
+                case FFmpegPreset.HapQ: return "hap";
+            }
+
+            return null;
+        }
+        public static string GetAdditionalFormatVideoArguments(this FFmpegPreset preset)
+        {
+            //If no choice -c:v(videocodec) it will use default codec(libx264)
+            //Hevc is mean h265(libx265)
+            switch (preset)
+            {
+                case FFmpegPreset.H264Default: return "-pix_fmt yuv420p";
+                case FFmpegPreset.H264Nvidia: return "-pix_fmt yuv420p";
+                case FFmpegPreset.H264Lossless420: return "-pix_fmt yuv420p -preset ultrafast -crf 0";
+                case FFmpegPreset.H264Lossless444: return "-pix_fmt yuv444p -preset ultrafast -crf 0";
+                case FFmpegPreset.HevcDefault: return "-pix_fmt yuv420p";
+                case FFmpegPreset.HevcNvidia: return "-pix_fmt yuv420p";
+                case FFmpegPreset.ProRes422: return "-pix_fmt yuv422p10le";
+                case FFmpegPreset.ProRes4444: return " -pix_fmt yuva444p10le";
+                case FFmpegPreset.VP8Default: return "-pix_fmt yuv420p";
+                case FFmpegPreset.VP9Default:
+                case FFmpegPreset.Hap: return "";
+                case FFmpegPreset.HapAlpha: return "-format hap_alpha";
+                case FFmpegPreset.HapQ: return "-format hap_q";
+            }
+
+            return null;
+        }
+
+        public static string GetOptions(this FFmpegPreset preset)
+        {
+            switch (preset)
+            {
+                case FFmpegPreset.H264Default: return "-pix_fmt yuv420p";
+                case FFmpegPreset.H264Nvidia: return "-c:v h264_nvenc -pix_fmt yuv420p";
+                case FFmpegPreset.H264Lossless420: return "-pix_fmt yuv420p -preset ultrafast -crf 0";
+                case FFmpegPreset.H264Lossless444: return "-pix_fmt yuv444p -preset ultrafast -crf 0";
+                case FFmpegPreset.HevcDefault: return "-c:v libx265 -pix_fmt yuv420p";
+                case FFmpegPreset.HevcNvidia: return "-c:v hevc_nvenc -pix_fmt yuv420p";
+                case FFmpegPreset.ProRes422: return "-c:v prores_ks -pix_fmt yuv422p10le";
+                case FFmpegPreset.ProRes4444: return "-c:v prores_ks -pix_fmt yuva444p10le";
+                case FFmpegPreset.VP8Default: return "-c:v libvpx -pix_fmt yuv420p";
+                case FFmpegPreset.VP9Default: return "-c:v libvpx-vp9";
+                case FFmpegPreset.Hap: return "-c:v hap";
+                case FFmpegPreset.HapAlpha: return "-c:v hap -format hap_alpha";
+                case FFmpegPreset.HapQ: return "-c:v hap -format hap_q";
+            }
+
+            return null;
+        }
+    }
+}

--- a/Packages/io.github.ruccho.ffmpegrecorder/Editor/Scripts/FFmpegPreset.cs.meta
+++ b/Packages/io.github.ruccho.ffmpegrecorder/Editor/Scripts/FFmpegPreset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a693dfcd27799d54b86b45dc7c00cbf1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/io.github.ruccho.ffmpegrecorder/Editor/Scripts/FFmpegRecorderEditor.cs
+++ b/Packages/io.github.ruccho.ffmpegrecorder/Editor/Scripts/FFmpegRecorderEditor.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.IO;
+using System.Linq;
 using UnityEditor;
 using UnityEditor.Recorder;
 using UnityEngine;
@@ -11,19 +11,31 @@ namespace Ruccho.FFmpegRecorder
     {
         private SerializedProperty ffmpegExecutablePath;
         private SerializedProperty extension;
+        private SerializedProperty usePreset;
+        private SerializedProperty preset;
         private SerializedProperty videoCodec;
         private SerializedProperty videoBitrate;
         private SerializedProperty videoArguments;
         private SerializedProperty audioCodec;
         private SerializedProperty audioArguments;
-        
+        private GUIContent[] presetLabels;
+        private int[] presetOptions;
+        private static int padval = 30;
+
         protected override void OnEnable()
         {
             base.OnEnable();
             if (target != null)
             {
+                //Initialize presets
+                var presets = FFmpegPreset.GetValues(typeof(FFmpegPreset));
+                presetLabels = presets.Cast<FFmpegPreset>().Select(p => new GUIContent(p.GetDisplayName())).ToArray();
+                presetOptions = presets.Cast<int>().ToArray();
+
                 ffmpegExecutablePath = serializedObject.FindProperty("ffmpegExecutablePath");
                 extension = serializedObject.FindProperty("extension");
+                usePreset = serializedObject.FindProperty("usePreset");
+                preset = serializedObject.FindProperty("preset");
                 videoCodec = serializedObject.FindProperty("videoCodec");
                 videoBitrate = serializedObject.FindProperty("videoBitrate");
                 videoArguments = serializedObject.FindProperty("videoArguments");
@@ -31,17 +43,66 @@ namespace Ruccho.FFmpegRecorder
                 audioArguments = serializedObject.FindProperty("audioArguments");
             }
         }
-        
+
+        protected override void ImageRenderOptionsGUI()
+        {
+            base.ImageRenderOptionsGUI();
+            //Check project audioManager setting is disable(e.g. some project using other audio system it will be disable)
+            var audioManager = AssetDatabase.LoadAllAssetsAtPath("ProjectSettings/AudioManager.asset")[0];
+            var serializedManager = new SerializedObject(audioManager);
+            var disableAudioProp = serializedManager.FindProperty("m_DisableAudio");
+            if (disableAudioProp.boolValue)
+            {
+                EditorGUILayout.HelpBox(
+                    "Audio setting is disabled in project settings .\n If your project using other audio system current is not support recode",
+                    MessageType.Warning);
+            }
+        }
+
         protected override void FileTypeAndFormatGUI()
         {
+            EditorGUILayout.BeginHorizontal();
             EditorGUILayout.PropertyField(ffmpegExecutablePath);
-            EditorGUILayout.PropertyField(extension);
-            EditorGUILayout.PropertyField(videoCodec);
-            EditorGUILayout.PropertyField(videoBitrate);
-            EditorGUILayout.PropertyField(videoArguments);
+            var oldPath = Application.dataPath;
+            if (GUILayout.Button(new GUIContent("...", " Select ffmpeg path"), GUILayout.Width(30)))
+            {
+                if (!string.IsNullOrEmpty(ffmpegExecutablePath.stringValue))
+                    oldPath = ffmpegExecutablePath.stringValue;
+                var newPath = EditorUtility.OpenFilePanel("Select ffmpeg.exe path", oldPath, "exe");
+                if (!string.IsNullOrEmpty(newPath))
+                {
+                    ffmpegExecutablePath.stringValue = newPath;
+                }
+            }
+
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.PrefixLabel("Preview ffmpeg path");
+            EditorGUILayout.LabelField(ffmpegExecutablePath.stringValue);
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.PropertyField(usePreset);
+            if (!usePreset.boolValue)
+            {
+                EditorGUILayout.PropertyField(extension);
+                EditorGUILayout.PropertyField(videoCodec);
+            }
+            else
+            {
+                EditorGUI.BeginChangeCheck();
+                EditorGUILayout.IntPopup(preset, presetLabels, presetOptions);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    var ffmpegPreset = (FFmpegPreset)preset.enumValueIndex;
+                    extension.stringValue = ffmpegPreset.GetSuffix();
+                    videoCodec.stringValue = ffmpegPreset.GetVideoCodec();
+                    videoArguments.stringValue = ffmpegPreset.GetAdditionalFormatVideoArguments();
+                }
+            }
+
+            EditorGUILayout.PropertyField(videoBitrate, new GUIContent("VideoBitrate(Kb/s)"));
             EditorGUILayout.PropertyField(audioCodec);
+            EditorGUILayout.PropertyField(videoArguments);
             EditorGUILayout.PropertyField(audioArguments);
         }
-        
     }
 }

--- a/Packages/io.github.ruccho.ffmpegrecorder/Editor/Scripts/FFmpegRecorderSettings.cs
+++ b/Packages/io.github.ruccho.ffmpegrecorder/Editor/Scripts/FFmpegRecorderSettings.cs
@@ -11,29 +11,33 @@ namespace Ruccho.FFmpegRecorder
     {
         public ImageInputSelector ImageInputSelector => imageInputSelector;
         [SerializeField] ImageInputSelector imageInputSelector = new ImageInputSelector();
-        
+
         public AudioInputSettings AudioInputSettings => audioInputSettings;
         [SerializeField] AudioInputSettings audioInputSettings = new AudioInputSettings();
 
         public string FFmpegExecutablePath => ffmpegExecutablePath;
         [SerializeField] private string ffmpegExecutablePath = default;
-        
-        [SerializeField]
-        private string extension = "mp4";
-        protected override string Extension => extension;
         public string OutputExtension => extension;
+        public bool UsePreset = false;
         
+        [SerializeField] FFmpegPreset preset;
+        public FFmpegPreset Preset => preset;
+
+        [SerializeField] private string extension = "mp4";
+        protected override string Extension => extension;
+        [SerializeField] private bool usePreset = false;
         public string VideoCodec => videoCodec;
         [SerializeField] private string videoCodec;
         public string AudioCodec => audioCodec;
-        [SerializeField] private string audioCodec;
+        [SerializeField] private string audioCodec = "aac";
         public int VideoBitrate => videoBitrate;
         [SerializeField] private int videoBitrate = 0;
         public string VideoArguments => videoArguments;
         [SerializeField] private string videoArguments;
         public string AudioArguments => audioArguments;
         [SerializeField] private string audioArguments;
-        
+        private int[] presetOptions;
+
         public override IEnumerable<RecorderInputSettings> InputsSettings
         {
             get
@@ -42,7 +46,5 @@ namespace Ruccho.FFmpegRecorder
                 yield return audioInputSettings;
             }
         }
-        
-        
     }
 }


### PR DESCRIPTION
Hello Ruccho,
I experimented using ffmpeg to record my game and make some improvements during use.
I using Windows, Unity 2022.3.14 and Recorder 4.0.2
My project is using Fmod instead internal audio system so I disabled Unity audio I found when disabled but allowing record audio will cause crashes so I fixed this.
Below is more detail about what I doing.
Use OpenFilePanel to select the user's ffmpeg directory.
Add some default preset for common format.
Check that the user project is audio disabled to prevent crashes.

Additionally a bug report, I found that my device output record is upside down because Unity is writing pixels from down to top.
I didn't deal with that bug this time. But I think the naive way is to add the option to rotate the output of FFmpeg.